### PR TITLE
Specify that time invariant variables must be numeric

### DIFF
--- a/man/microsynth.Rd
+++ b/man/microsynth.Rd
@@ -112,7 +112,7 @@ to the maximum time that appears in the column given by \code{timevar}.}
 
 \item{match.covar}{Either a logical or a vector of variable names that
 indicates which time invariant covariates
-are to be used for weighting.  Weights are
+are to be used for weighting.  Covariates must be numeric variables.  Weights are
 calculated so that treatment and synthetic control exactly match across
 these variables.  If \code{match.covar = TRUE}, it is set equal to a vector
 of variable names corresponding to the time invariant variables that


### PR DESCRIPTION
I ran into this warning when attempting to use Factor type variable in the `match.covar` parameter.

``` WARNING: <var_name> is a non-numeric variable.  It will be removed from match.covar.```